### PR TITLE
Implement card grouping and UI tweaks

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { AppBar, Toolbar, Button, Tabs, Tab, Box, Typography, Grid, TextField, Dialog, DialogContent, Snackbar, Alert } from '@mui/material';
+import { AppBar, Toolbar, Button, Tabs, Tab, Box, Typography, Grid, TextField, Dialog, DialogContent, Snackbar, Alert, FormControl, InputLabel, Select, MenuItem, Checkbox, FormGroup, FormControlLabel, Chip, Stack } from '@mui/material';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000';
 
@@ -12,6 +12,10 @@ function App() {
   const [dialogCard, setDialogCard] = useState(null);
   const [snackOpen, setSnackOpen] = useState(false);
   const [config, setConfig] = useState({ previewSize: 128 });
+  const [groups, setGroups] = useState([]);
+  const [selectedGroup, setSelectedGroup] = useState('default');
+  const [uploadGroups, setUploadGroups] = useState(['default']);
+  const [newGroupName, setNewGroupName] = useState('');
 
   useEffect(() => {
     fetch(`${API_URL}/config`)
@@ -27,7 +31,9 @@ function App() {
   useEffect(() => {
     if (user) {
       loadCards();
+      loadGroups();
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user]);
 
   const loadCards = () => {
@@ -36,12 +42,24 @@ function App() {
       .then(setCards);
   };
 
+  const loadGroups = () => {
+    fetch(`${API_URL}/groups`, { credentials: 'include' })
+      .then(res => res.json())
+      .then(data => {
+        setGroups(data);
+        if (!data.find(g => g.id === selectedGroup)) {
+          setSelectedGroup('default');
+        }
+      });
+  };
+
   const handleUpload = (e) => {
     e.preventDefault();
     if (!file) return;
     const formData = new FormData();
     formData.append('file', file);
     formData.append('comment', comment);
+    formData.append('groups', JSON.stringify(uploadGroups));
     fetch(`${API_URL}/upload`, {
       method: 'POST',
       credentials: 'include',
@@ -49,14 +67,21 @@ function App() {
     }).then(() => {
       setFile(null);
       setComment('');
+      setUploadGroups(['default']);
       loadCards();
+      loadGroups();
       setSnackOpen(true);
     });
   };
 
   if (!user) {
     return (
-      <Box sx={{ p:4 }}>
+      <Box sx={{ height:'100vh', display:'flex', flexDirection:'column', justifyContent:'center', alignItems:'center' }}>
+        <svg width="120" height="120" viewBox="0 0 120 120">
+          <rect x="10" y="10" width="100" height="100" rx="20" fill="#1976d2" />
+          <text x="60" y="70" textAnchor="middle" fontSize="40" fill="white">AC</text>
+        </svg>
+        <Typography variant="h4" sx={{ my:2 }}>AnyCard</Typography>
         <Button variant="contained" color="primary" href={`${API_URL}/auth/google`}>
           Login with Google
         </Button>
@@ -75,17 +100,26 @@ function App() {
       <Tabs value={tab} onChange={(_, v) => setTab(v)} centered>
         <Tab label="Your Cards" />
         <Tab label="Upload" />
+        <Tab label="Groups" />
       </Tabs>
       <Box sx={{ p:2 }} hidden={tab!==0}>
+        <FormControl sx={{ mb:2, minWidth:200 }}>
+          <InputLabel>Group</InputLabel>
+          <Select value={selectedGroup} label="Group" onChange={e=>setSelectedGroup(e.target.value)}>
+            {groups.map(g=>(
+              <MenuItem key={g.id} value={g.id}>{g.name} ({g.count})</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
         {cards.length === 0 && <Typography>No cards uploaded.</Typography>}
         <Grid container spacing={2}>
-          {cards.map((card, i) => (
+          {cards.filter(c=>selectedGroup==='all'?true:c.groups.includes(selectedGroup)).map((card, i) => (
             <Grid item key={i}>
               <Box
                 component="img"
                 src={`${API_URL}${card.preview}`}
                 alt="card"
-                sx={{ width: config.previewSize, height: config.previewSize, objectFit: 'cover', cursor: 'pointer' }}
+                sx={{ width: config.previewSize, height: config.previewSize, objectFit: 'cover', cursor: 'pointer', borderRadius:2 }}
                 onClick={() => setDialogCard(card)}
               />
             </Grid>
@@ -96,8 +130,39 @@ function App() {
         <form onSubmit={handleUpload}>
           <input type="file" accept="image/*" onChange={e=>setFile(e.target.files[0])} />
           <TextField label="Comment" multiline value={comment} onChange={e=>setComment(e.target.value)} sx={{ mx:2, width:'300px' }} />
+          <FormGroup row sx={{ my:1 }}>
+            {groups.map(g=>(
+              <FormControlLabel key={g.id} control={<Checkbox checked={uploadGroups.includes(g.id)} onChange={e=>{
+                if(e.target.checked) setUploadGroups([...uploadGroups,g.id]); else setUploadGroups(uploadGroups.filter(x=>x!==g.id));
+              }} />} label={g.name} />
+            ))}
+          </FormGroup>
           <Button type="submit" variant="contained">Upload</Button>
         </form>
+      </Box>
+      <Box sx={{ p:2 }} hidden={tab!==2}>
+        <Box sx={{ display:'flex', alignItems:'center', mb:2 }}>
+          <TextField label="New group" size="small" sx={{ mr:2 }} value={newGroupName} onChange={e=>setNewGroupName(e.target.value)} />
+          <Button variant="contained" onClick={()=>{
+            fetch(`${API_URL}/groups`, {method:'POST', credentials:'include', headers:{'Content-Type':'application/json'}, body:JSON.stringify({name:newGroupName||'Group'})}).then(()=>{setNewGroupName(''); loadGroups();});
+          }}>Add</Button>
+        </Box>
+        {groups.map(g=> (
+          <Box key={g.id} sx={{ mb:1, display:'flex', alignItems:'center' }}>
+            <TextField size="small" value={g.name} onChange={e=>setGroups(groups.map(gr=>gr.id===g.id?{...gr,name:e.target.value}:gr))} sx={{ mr:2 }} />
+            <Typography sx={{ mr:2 }}>({g.count})</Typography>
+            {g.id!=='default' && (
+              <>
+                <Button size="small" onClick={()=>{
+                  fetch(`${API_URL}/groups/${g.id}`, {method:'PUT', credentials:'include', headers:{'Content-Type':'application/json'}, body:JSON.stringify({name:g.name})}).then(()=>loadGroups());
+                }}>Save</Button>
+                <Button size="small" color="error" onClick={()=>{
+                  fetch(`${API_URL}/groups/${g.id}`, {method:'DELETE', credentials:'include'}).then(()=>loadGroups());
+                }}>Delete</Button>
+              </>
+            )}
+          </Box>
+        ))}
       </Box>
       <Dialog open={!!dialogCard} onClose={() => setDialogCard(null)} fullScreen>
         <AppBar sx={{ position: 'relative' }}>
@@ -106,9 +171,18 @@ function App() {
             <Button color="inherit" onClick={() => setDialogCard(null)}>Close</Button>
           </Toolbar>
         </AppBar>
-        <DialogContent sx={{ p:2, display:'flex', justifyContent:'center' }}>
+        <DialogContent sx={{ p:2, display:'flex', flexDirection:'column', alignItems:'center' }}>
           {dialogCard && (
-            <Box component="img" src={`${API_URL}${dialogCard.original}`} alt="card" sx={{ maxWidth:'100%', maxHeight:'100%' }} />
+            <>
+              <Box component="img" src={`${API_URL}${dialogCard.original}`} alt="card" sx={{ width:'100%', height:'100%', objectFit:'contain' }} />
+              <Stack direction="row" spacing={1} sx={{ mt:2, flexWrap:'wrap', justifyContent:'center' }}>
+                {groups.map(g=>(
+                  <Chip key={g.id} label={g.name} color={dialogCard.groups?.includes(g.id)?'primary':'default'} onClick={()=>{
+                    fetch(`${API_URL}/cards/${dialogCard.filename}/groups/${g.id}`, {method:'POST', credentials:'include'}).then(()=>{ loadCards(); loadGroups(); setDialogCard({...dialogCard, groups: dialogCard.groups.includes(g.id)? dialogCard.groups.filter(x=>x!==g.id):[...dialogCard.groups,g.id]}); });
+                  }} />
+                ))}
+              </Stack>
+            </>
           )}
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
## Summary
- support grouping of cards in backend
- add group management API endpoints
- filter cards by group and assign groups in the UI
- show groups in card dialog with toggle
- tweak login screen with simple logo
- round card previews and keep full image proportions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ea708a99c8328a81c2b1094b3aefe