### PR TITLE
Frontend improvements for cropping and grouping

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,8 +15,7 @@
         "react": "^19.1.0",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
-        "react-dom": "^19.1.0",
-        "react-image-crop": "^10.1.1"
+        "react-dom": "^19.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -3164,28 +3163,6 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
-      }
-    },
-    "node_modules/react-image-crop": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-10.1.1.tgz",
-      "integrity": "sha512-2tlBOaqthdw7GeCC6cILONo7aj0tRdJrfNxNXUv1UaetOnpSkB7KeUJLZ0O2Au2F9oJ7fnZM2aw4ECjaV5ebtw==",
-      "deprecated": "missing types",
-      "license": "ISC",
-      "dependencies": {
-        "clsx": "^1.2.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.13.1"
-      }
-    },
-    "node_modules/react-image-crop/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,8 @@
         "@mui/material": "^7.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-easy-crop": "^5.4.2"
+        "react-easy-crop": "^5.4.2",
+        "react-image-crop": "^10.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -3115,6 +3116,28 @@
       "peerDependencies": {
         "react": ">=16.4.0",
         "react-dom": ">=16.4.0"
+      }
+    },
+    "node_modules/react-image-crop": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-10.1.1.tgz",
+      "integrity": "sha512-2tlBOaqthdw7GeCC6cILONo7aj0tRdJrfNxNXUv1UaetOnpSkB7KeUJLZ0O2Au2F9oJ7fnZM2aw4ECjaV5ebtw==",
+      "deprecated": "missing types",
+      "license": "ISC",
+      "dependencies": {
+        "clsx": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
+    "node_modules/react-image-crop/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,8 +13,9 @@
         "@mui/icons-material": "^7.2.0",
         "@mui/material": "^7.2.0",
         "react": "^19.1.0",
+        "react-dnd": "^16.0.1",
+        "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^19.1.0",
-        "react-easy-crop": "^5.4.2",
         "react-image-crop": "^10.1.1"
       },
       "devDependencies": {
@@ -1430,6 +1431,24 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@react-dnd/asap": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+      "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+      "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+      "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.19",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz",
@@ -2125,6 +2144,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dnd-core": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+      "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/asap": "^5.0.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "redux": "^4.2.0"
+      }
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -2397,7 +2427,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -2868,12 +2897,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/normalize-wheel": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
-      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3092,6 +3115,45 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-dnd": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+      "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.1",
+        "@react-dnd/shallowequal": "^4.0.1",
+        "dnd-core": "^16.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
+      "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
+      "license": "MIT",
+      "dependencies": {
+        "dnd-core": "^16.0.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -3102,20 +3164,6 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
-      }
-    },
-    "node_modules/react-easy-crop": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.4.2.tgz",
-      "integrity": "sha512-V+GQUTkNWD8gK0mbZQfwTvcDxyCB4GS0cM36is8dAcvnsHY7DMEDP2D5IqHju55TOiCHwElJPVOYDgiu8BEiHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "normalize-wheel": "^1.0.1",
-        "tslib": "^2.0.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.4.0",
-        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-image-crop": {
@@ -3170,6 +3218,15 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/resolve": {
@@ -3359,12 +3416,6 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,8 +16,9 @@
     "@mui/material": "^7.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-easy-crop": "^5.4.2",
-    "react-image-crop": "^10.1.1"
+    "react-image-crop": "^10.1.1",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,6 @@
     "@mui/material": "^7.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-image-crop": "^10.1.1",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "@mui/material": "^7.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-easy-crop": "^5.4.2"
+    "react-easy-crop": "^5.4.2",
+    "react-image-crop": "^10.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { AppBar, Toolbar, Button, Tabs, Tab, Box, Typography, Grid, TextField, Dialog, DialogContent, Snackbar, Alert, FormControl, InputLabel, Select, MenuItem, Checkbox, FormGroup, FormControlLabel, Chip, Stack, ListSubheader, Avatar } from '@mui/material';
+import { useDrop } from 'react-dnd';
+import { NativeTypes } from 'react-dnd-html5-backend';
 import ReactCrop from 'react-image-crop';
 import 'react-image-crop/dist/ReactCrop.css';
 
@@ -27,6 +29,14 @@ function App() {
   const [completedCrop, setCompletedCrop] = useState(null);
   const imageRef = useRef(null);
   const fileInputRef = useRef(null);
+  const [{ isOver }, drop] = useDrop(() => ({
+    accept: [NativeTypes.FILE],
+    drop: (item) => {
+      const f = item.files?.[0];
+      if (f) setFile(f);
+    },
+    collect: monitor => ({ isOver: monitor.isOver() }),
+  }));
 
   useEffect(() => {
     fetch(`${API_URL}/config`)
@@ -231,10 +241,9 @@ function App() {
         <form onSubmit={handleUpload}>
           <input type="file" accept="image/*" ref={fileInputRef} style={{display:'none'}} onChange={e=>setFile(e.target.files[0])} />
           <Box
+            ref={drop}
             onClick={file ? undefined : ()=>fileInputRef.current?.click()}
-            onDragOver={e=>e.preventDefault()}
-            onDrop={e=>{ e.preventDefault(); if(e.dataTransfer.files && e.dataTransfer.files[0]) setFile(e.dataTransfer.files[0]); }}
-            sx={{ width:'100%', height:'25vh', border:'2px dashed gray', mb:1, display:'flex', justifyContent:'center', alignItems:'center', position:'relative', overflow:'hidden', cursor: file ? 'default' : 'pointer' }}
+            sx={{ width:'100%', maxWidth:400, height:'25vh', mx:'auto', border:'2px dashed gray', mb:1, display:'flex', justifyContent:'center', alignItems:'center', position:'relative', overflow:'hidden', cursor: file ? 'default' : 'pointer', borderColor: isOver ? 'primary.main' : 'gray' }}
           >
             {file ? (
               <ReactCrop
@@ -253,7 +262,7 @@ function App() {
                 />
               </ReactCrop>
             ) : (
-              <Typography color="primary" sx={{ textDecoration:'underline' }}>Drag and drop or click to choose file...</Typography>
+              <Typography color="primary" sx={{ textDecoration:'underline' }}>Click or drop a file...</Typography>
             )}
           </Box>
           {file && (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useState, useRef, useCallback } from 'react';
-import { AppBar, Toolbar, Button, Tabs, Tab, Box, Typography, Grid, TextField, Dialog, DialogContent, Snackbar, Alert, FormControl, InputLabel, Select, MenuItem, Checkbox, FormGroup, FormControlLabel, Chip, Stack, Slider } from '@mui/material';
-import Cropper from 'react-easy-crop';
+import { useEffect, useState, useRef, Fragment } from 'react';
+import { AppBar, Toolbar, Button, Tabs, Tab, Box, Typography, Grid, TextField, Dialog, DialogContent, Snackbar, Alert, FormControl, InputLabel, Select, MenuItem, Checkbox, FormGroup, FormControlLabel, Chip, Stack, ListSubheader, Avatar } from '@mui/material';
+import ReactCrop from 'react-image-crop';
+import 'react-image-crop/dist/ReactCrop.css';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000';
 
@@ -22,10 +23,8 @@ function App() {
   const [shareEmails, setShareEmails] = useState([]);
   const [shareInput, setShareInput] = useState('');
   const [sharedGroups, setSharedGroups] = useState([]);
-  const [crop, setCrop] = useState({ x: 0, y: 0 });
-  const [zoom, setZoom] = useState(1);
-  const [croppedAreaPixels, setCroppedAreaPixels] = useState(null);
-  const onCropComplete = useCallback((_, area) => setCroppedAreaPixels(area), []);
+  const [crop, setCrop] = useState({ unit: '%', x: 0, y: 0, width: 100, height: 100 });
+  const imageRef = useRef(null);
   const fileInputRef = useRef(null);
 
   useEffect(() => {
@@ -80,6 +79,12 @@ function App() {
       });
   };
 
+  useEffect(() => {
+    if (user && tab !== 2) {
+      loadGroups();
+    }
+  }, [tab]);
+
   const loadSharedGroups = () => {
     fetch(`${API_URL}/shared-groups`, { credentials:'include' })
       .then(res => res.json())
@@ -93,24 +98,26 @@ function App() {
     img.src = url;
   });
 
+  useEffect(() => {
+    if (file) {
+      setCrop({ unit: '%', x: 0, y: 0, width: 100, height: 100 });
+    }
+  }, [file]);
+
   const getCroppedBlob = async () => {
-    if (!file || !croppedAreaPixels) return file;
+    if (!file) return file;
     const image = await createImage(URL.createObjectURL(file));
+    const scaleX = image.naturalWidth / 100;
+    const scaleY = image.naturalHeight / 100;
+    const sx = crop.x * scaleX;
+    const sy = crop.y * scaleY;
+    const sw = crop.width * scaleX;
+    const sh = crop.height * scaleY;
     const canvas = document.createElement('canvas');
-    canvas.width = croppedAreaPixels.width;
-    canvas.height = croppedAreaPixels.height;
+    canvas.width = sw;
+    canvas.height = sh;
     const ctx = canvas.getContext('2d');
-    ctx.drawImage(
-      image,
-      croppedAreaPixels.x,
-      croppedAreaPixels.y,
-      croppedAreaPixels.width,
-      croppedAreaPixels.height,
-      0,
-      0,
-      croppedAreaPixels.width,
-      croppedAreaPixels.height
-    );
+    ctx.drawImage(image, sx, sy, sw, sh, 0, 0, sw, sh);
     return new Promise(resolve => {
       canvas.toBlob(b => resolve(new File([b], file.name, { type: 'image/jpeg' })), 'image/jpeg');
     });
@@ -123,7 +130,8 @@ function App() {
     const formData = new FormData();
     formData.append('file', croppedFile);
     formData.append('comment', comment);
-    formData.append('groups', JSON.stringify(uploadGroups));
+    const groupsForUpload = uploadGroups.includes('default') ? uploadGroups : [...uploadGroups, 'default'];
+    formData.append('groups', JSON.stringify(groupsForUpload));
     fetch(`${API_URL}/upload`, {
       method: 'POST',
       credentials: 'include',
@@ -159,6 +167,10 @@ function App() {
       <AppBar position="static">
         <Toolbar>
           <Typography variant="h6" sx={{ flexGrow: 1 }}>AnyCard</Typography>
+          <Box sx={{ display:'flex', alignItems:'center', mr:2 }}>
+            <Avatar src={user.photos?.[0]?.value} sx={{ width:32, height:32, mr:1 }} />
+            <Typography>{user.displayName}</Typography>
+          </Box>
           <Button color="inherit" href={`${API_URL}/auth/google`}>Change User</Button>
         </Toolbar>
       </AppBar>
@@ -172,15 +184,34 @@ function App() {
         <FormControl sx={{ mb:2, minWidth:200 }}>
           <InputLabel>Group</InputLabel>
           <Select value={selectedGroup} label="Group" onChange={e=>setSelectedGroup(e.target.value)}>
-            {[
-              ...groups,
-              ...sharedGroups.filter(sg=>sg.showInMy).map(sg=>({
-                ...sg,
-                id:`s:${sg.owner}:${sg.id}`,
-              }))
-            ].map(g=>(
-              <MenuItem key={g.id} value={g.id}>{g.name} ({g.count})</MenuItem>
-            ))}
+            {(() => {
+              const myGroups = [...groups].sort((a,b)=>{
+                if(a.id==='default') return -1;
+                if(b.id==='default') return 1;
+                return 0;
+              });
+              const shared = sharedGroups.filter(sg=>sg.showInMy).reduce((acc, sg)=>{
+                const key = sg.owner;
+                if(!acc[key]) acc[key]=[];
+                acc[key].push({ ...sg, id:`s:${sg.owner}:${sg.id}` });
+                return acc;
+              }, {});
+              return (
+                <>
+                  {myGroups.map(g=>(
+                    <MenuItem key={g.id} value={g.id}>{g.name} ({g.count})</MenuItem>
+                  ))}
+                  {Object.entries(shared).map(([owner, arr])=>(
+                    <Fragment key={owner}>
+                      <ListSubheader>{owner}</ListSubheader>
+                      {arr.map(g=>(
+                        <MenuItem key={g.id} value={g.id}>{g.name} ({g.count})</MenuItem>
+                      ))}
+                    </Fragment>
+                  ))}
+                </>
+              );
+            })()}
           </Select>
         </FormControl>
         {cards.length === 0 && <Typography>No cards uploaded.</Typography>}
@@ -214,32 +245,47 @@ function App() {
             sx={{ width:'100%', height:'25vh', border:'2px dashed gray', mb:1, display:'flex', justifyContent:'center', alignItems:'center', position:'relative', overflow:'hidden', cursor: file ? 'default' : 'pointer' }}
           >
             {file ? (
-              <Cropper
-                image={URL.createObjectURL(file)}
+              <ReactCrop
                 crop={crop}
-                zoom={zoom}
-                aspect={1}
-                onCropChange={setCrop}
-                onZoomChange={setZoom}
-                onCropComplete={onCropComplete}
-              />
+                onChange={c => setCrop(c)}
+                keepSelection
+              >
+                <img
+                  ref={imageRef}
+                  alt="crop"
+                  src={URL.createObjectURL(file)}
+                  style={{ maxHeight: '100%', maxWidth: '100%' }}
+                />
+              </ReactCrop>
             ) : (
               <Typography color="primary" sx={{ textDecoration:'underline' }}>Drag and drop or click to choose file...</Typography>
             )}
           </Box>
           {file && (
-            <Typography onClick={()=>{ setFile(null); setCroppedAreaPixels(null); if(fileInputRef.current) fileInputRef.current.value=''; }} color="primary" sx={{ cursor:'pointer', mb:1, textDecoration:'underline' }}>Reset selected file</Typography>
-          )}
-          {file && (
-            <Slider value={zoom} min={1} max={3} step={0.1} onChange={(_,v)=>setZoom(v)} sx={{ mb:2 }} />
+            <Typography onClick={()=>{ setFile(null); if(fileInputRef.current) fileInputRef.current.value=''; }} color="primary" sx={{ cursor:'pointer', mb:1, textDecoration:'underline' }}>Reset selected file</Typography>
           )}
           <TextField label="Comment" multiline fullWidth value={comment} onChange={e=>setComment(e.target.value)} sx={{ mb:2 }} />
           <FormGroup row sx={{ my:1 }}>
-            {groups.map(g=>(
-              <FormControlLabel key={g.id} control={<Checkbox checked={uploadGroups.includes(g.id)} onChange={e=>{
-                if(e.target.checked) setUploadGroups([...uploadGroups,g.id]); else setUploadGroups(uploadGroups.filter(x=>x!==g.id));
-              }} />} label={g.name} />
-            ))}
+            {groups.map(g=>{
+              const checked = uploadGroups.includes(g.id);
+              const disabled = g.id === 'default';
+              return (
+                <FormControlLabel
+                  key={g.id}
+                  control={
+                    <Checkbox
+                      checked={disabled || checked}
+                      disabled={disabled}
+                      onChange={e=>{
+                        if(e.target.checked) setUploadGroups(Array.from(new Set([...uploadGroups,g.id])));
+                        else setUploadGroups(uploadGroups.filter(x=>x!==g.id));
+                      }}
+                    />
+                  }
+                  label={g.name}
+                />
+              );
+            })}
           </FormGroup>
           <Button type="submit" variant="contained">Upload</Button>
         </form>
@@ -255,7 +301,9 @@ function App() {
           <Box key={g.id} sx={{ mb:1, display:'flex', alignItems:'center' }}>
             <TextField size="small" value={g.name} onChange={e=>setGroups(groups.map(gr=>gr.id===g.id?{...gr,name:e.target.value}:gr))} sx={{ mr:2 }} />
             <Typography sx={{ mr:2 }}>({g.count})</Typography>
-            <Button size="small" onClick={()=>{ setShareGroup(g); setShareEmails(g.emails||[]); setShareInput(''); }}>Share</Button>
+            <Button size="small" onClick={()=>{ setShareGroup(g); setShareEmails(g.emails||[]); setShareInput(''); }}>
+              Share ({g.emails?.length || 0})
+            </Button>
             {g.id!=='default' && (
               <>
                 {g.name !== g.originalName && (
@@ -280,18 +328,24 @@ function App() {
         ))}
       </Box>
       <Box sx={{ p:2 }} hidden={tab!==3}>
-        {sharedGroups.map(sg => (
-          <Box key={`${sg.owner}_${sg.id}`} sx={{ mb:1 }}>
-            <Box sx={{ display:'flex', alignItems:'center' }}>
-              <Typography sx={{ mr:2 }}>{sg.name} ({sg.count})</Typography>
-              <FormControlLabel control={<Checkbox checked={sg.showInMy} onChange={e=>{
-                fetch(`${API_URL}/shared-groups/${sg.owner}/${sg.id}/show`, {method:'POST', credentials:'include', headers:{'Content-Type':'application/json'}, body:JSON.stringify({show:e.target.checked})}).then(loadSharedGroups);
-              }} />} label="Show in my groups" />
-              <Button size="small" color="error" onClick={()=>{
-                fetch(`${API_URL}/shared-groups/${sg.owner}/${sg.id}/delete`, {method:'POST', credentials:'include'}).then(()=>{ loadSharedGroups(); });
-              }}>Delete</Button>
-            </Box>
-            <Typography variant="caption" color="text.secondary" sx={{ ml:1 }}>{sg.owner}</Typography>
+        {Object.entries(sharedGroups.reduce((acc, g)=>{
+          if(!acc[g.owner]) acc[g.owner]=[]; acc[g.owner].push(g); return acc;
+        }, {})).map(([owner, arr])=>(
+          <Box key={owner} sx={{ mb:2 }}>
+            <Typography sx={{ fontWeight:'bold', mb:1 }}>{owner}</Typography>
+            {arr.map(sg => (
+              <Box key={`${sg.owner}_${sg.id}`} sx={{ mb:1 }}>
+                <Box sx={{ display:'flex', alignItems:'center' }}>
+                  <Typography sx={{ mr:2 }}>{sg.name} ({sg.count})</Typography>
+                  <FormControlLabel control={<Checkbox checked={sg.showInMy} onChange={e=>{
+                    fetch(`${API_URL}/shared-groups/${sg.owner}/${sg.id}/show`, {method:'POST', credentials:'include', headers:{'Content-Type':'application/json'}, body:JSON.stringify({show:e.target.checked})}).then(loadSharedGroups);
+                  }} />} label="Show in my groups" />
+                  <Button size="small" color="error" onClick={()=>{
+                    fetch(`${API_URL}/shared-groups/${sg.owner}/${sg.id}/delete`, {method:'POST', credentials:'include'}).then(()=>{ loadSharedGroups(); });
+                  }}>Delete</Button>
+                </Box>
+              </Box>
+            ))}
           </Box>
         ))}
       </Box>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,14 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { DndProvider } from 'react-dnd'
+import { HTML5Backend } from 'react-dnd-html5-backend'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <DndProvider backend={HTML5Backend}>
+      <App />
+    </DndProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- replace `react-easy-crop` with `react-image-crop` for unrestricted cropping
- show user name and avatar in the header
- group shared cards by owner on **Your Cards** and **Shared** tabs
- make default group mandatory on upload
- display share email count and reload groups when leaving tab

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f88e8752c8328b0cbd634962c856f