### PR TITLE
Implement card multi-select with confirmations

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -349,6 +349,22 @@ app.post('/cards/:file/groups/:groupId', ensureAuthenticated, (req, res) => {
   res.json(meta);
 });
 
+app.delete('/cards/:file', ensureAuthenticated, (req, res) => {
+  const userDir = getUserDir(req);
+  const file = path.join(userDir, req.params.file);
+  if (!fs.existsSync(file)) return res.status(404).json({ error: 'Not found' });
+  try {
+    fs.unlinkSync(file);
+  } catch {}
+  try {
+    fs.unlinkSync(path.join(userDir, 'previews', req.params.file));
+  } catch {}
+  try {
+    fs.unlinkSync(path.join(userDir, 'meta', req.params.file + '.json'));
+  } catch {}
+  res.json({ success: true });
+});
+
 app.use('/uploads', ensureAuthenticated, express.static(path.join(__dirname, 'uploads')));
 
 app.get('/config', (req, res) => {


### PR DESCRIPTION
## Summary
- support deleting cards via `DELETE /cards/:file`
- add long-press multi-select on card previews
- include confirmation popups for card and group deletions
- display snackbar errors instead of alerts

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f9d6118d483289dd150d9aebf5202