### PR TITLE
Fix language storage and add usage limits

### DIFF
--- a/backend/localization/en.json
+++ b/backend/localization/en.json
@@ -40,6 +40,10 @@
     "nameRequired": "Name required",
     "invalidChars": "Invalid characters",
     "nameUnique": "Name must be unique",
-    "deleteFailed": "Delete failed"
+    "deleteFailed": "Delete failed",
+    "limitCards": "Card limit reached",
+    "limitGroups": "Group limit reached",
+    "limitEmails": "Email limit exceeded",
+    "uploadFailed": "Upload failed"
   }
 }

--- a/backend/localization/ru.json
+++ b/backend/localization/ru.json
@@ -40,6 +40,10 @@
     "nameRequired": "Требуется имя",
     "invalidChars": "Недопустимые символы",
     "nameUnique": "Имя должно быть уникальным",
-    "deleteFailed": "Ошибка удаления"
+    "deleteFailed": "Ошибка удаления",
+    "limitCards": "Превышен лимит карт",
+    "limitGroups": "Превышен лимит групп",
+    "limitEmails": "Слишком много адресов",
+    "uploadFailed": "Ошибка загрузки"
   }
 }

--- a/frontend/src/localization/index.jsx
+++ b/frontend/src/localization/index.jsx
@@ -10,23 +10,16 @@ const LocalizationContext = createContext({
 
 export function LocalizationProvider({ children }) {
   const [data, setData] = useState({});
-  const [lang, setLang] = useState('en');
+  const [lang, setLang] = useState(() => localStorage.getItem('lang') || 'en');
 
   useEffect(() => {
     const saved = localStorage.getItem('lang');
-    if (saved) setLang(saved);
     fetch(`${API_URL}/localization`)
       .then(res => res.json())
       .then(obj => {
         setData(obj);
-        if (saved && obj[saved]) {
-          setLang(saved);
-        } else if (obj['en']) {
-          setLang('en');
-        } else {
-          const first = Object.keys(obj)[0];
-          if (first) setLang(first);
-        }
+        const candidate = saved && obj[saved] ? saved : obj['en'] ? 'en' : Object.keys(obj)[0];
+        if (candidate) setLang(candidate);
       });
   }, []);
 


### PR DESCRIPTION
## Summary
- make localization provider initialize from saved setting
- add usage limits on upload, groups, and share emails
- surface limit errors in frontend with new translations

## Testing
- `npm run lint`
- `npm install` in both frontend and backend
- `npm start` *(fails: OAuth client ID missing)*

------
https://chatgpt.com/codex/tasks/task_e_686fd1645d408328b9e16a5ffef9666b