### PR TITLE
Use SESSION_SECRET env var

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -2,3 +2,4 @@ PORT=4000
 GOOGLE_CLIENT_ID=your_client_id
 GOOGLE_CLIENT_SECRET=your_client_secret
 FRONTEND_URL=http://localhost:3000
+SESSION_SECRET=your_session_secret

--- a/backend/index.js
+++ b/backend/index.js
@@ -11,6 +11,11 @@ const sharp = require('sharp');
 
 require('dotenv').config();
 
+if (!process.env.SESSION_SECRET) {
+  console.error('SESSION_SECRET is required');
+  process.exit(1);
+}
+
 const app = express();
 const PORT = process.env.PORT || 4000;
 const PREVIEW_SIZE = parseInt(process.env.PREVIEW_SIZE) || 128;
@@ -145,7 +150,7 @@ app.use(cors({
 }));
 app.use(express.json());
 app.use(session({
-  secret: 'secret',
+  secret: process.env.SESSION_SECRET,
   resave: false,
   saveUninitialized: false,
 }));


### PR DESCRIPTION
## Summary
- replace hardcoded session secret with `SESSION_SECRET` env var
- exit server startup if `SESSION_SECRET` is missing
- document new env var in `backend/.env.sample`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686fd809564483288d3978ee95c3f0cd