### PR TITLE
Enforce image MIME check for uploads

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -225,6 +225,13 @@ app.post('/upload', ensureAuthenticated, (req, res) => {
       console.error('Upload error:', err);
       return res.status(500).json({ error: 'Upload failed' });
     }
+    const allowedMimeTypes = ['image/jpeg', 'image/png'];
+    if (!req.file || !allowedMimeTypes.includes(req.file.mimetype)) {
+      if (req.file && req.file.path) {
+        try { fs.unlinkSync(req.file.path); } catch {}
+      }
+      return res.status(400).json({ error: 'invalid_file_type' });
+    }
     try {
       const userDir = getUserDir(req);
       ensureDirs(userDir);

--- a/backend/localization/en.json
+++ b/backend/localization/en.json
@@ -45,6 +45,7 @@
     "limitGroups": "Group limit reached",
     "limitEmails": "Email limit exceeded",
     "uploadFailed": "Upload failed",
-    "fileTooLarge": "File too large"
+    "fileTooLarge": "File too large",
+    "invalidFileType": "Invalid file type"
   }
 }

--- a/backend/localization/ru.json
+++ b/backend/localization/ru.json
@@ -45,6 +45,7 @@
     "limitGroups": "Превышен лимит групп",
     "limitEmails": "Слишком много адресов",
     "uploadFailed": "Ошибка загрузки",
-    "fileTooLarge": "Слишком большой файл"
+    "fileTooLarge": "Слишком большой файл",
+    "invalidFileType": "Недопустимый тип файла"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -237,6 +237,7 @@ function App() {
       const data = await resp.json().catch(() => ({}));
       if (data.error === 'limit_cards') showError(t('errors.limitCards'));
       else if (data.error === 'file_too_large') showError(t('errors.fileTooLarge'));
+      else if (data.error === 'invalid_file_type') showError(t('errors.invalidFileType'));
       else showError(t('errors.uploadFailed'));
       return;
     }


### PR DESCRIPTION
## Summary
- validate uploaded file MIME type and only allow JPEG/PNG images
- localize invalid file type error

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6870b88994d8832889be7c1242be67a3