### PR TITLE
Validate shared owner accounts

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -55,6 +55,12 @@ function ensureDirs(dir) {
   fs.mkdirSync(path.join(dir, 'meta'), { recursive: true });
 }
 
+function ownerExists(owner) {
+  if (!validPathComponent(owner)) return false;
+  const dir = path.join(__dirname, 'uploads', owner);
+  return fs.existsSync(dir);
+}
+
 function groupsPath(dir) {
   return path.join(dir, 'groups.json');
 }
@@ -377,14 +383,16 @@ app.post('/shared-groups/:owner/:id/delete', ensureAuthenticated, (req, res) => 
   if (!validPathComponent(req.params.owner)) {
     return res.status(400).json({ error: 'Invalid input' });
   }
+  const ownerDir = path.join(__dirname, 'uploads', req.params.owner);
+  if (!ownerExists(req.params.owner)) {
+    return res.status(404).json({ error: 'owner_not_found' });
+  }
   const email = req.user.emails[0].value;
   const myDir = getUserDir(req);
   const state = loadSharedState(myDir);
   const key = req.params.owner + '/' + req.params.id;
   if (!state.hidden.includes(key)) state.hidden.push(key);
   saveSharedState(myDir, state);
-  const ownerDir = path.join(__dirname, 'uploads', req.params.owner);
-  ensureDirs(ownerDir);
   const rej = loadRejections(ownerDir);
   if (!rej[req.params.id]) rej[req.params.id] = [];
   if (!rej[req.params.id].includes(email)) rej[req.params.id].push(email);
@@ -396,6 +404,10 @@ app.post('/shared-groups/:owner/:id/show', ensureAuthenticated, (req, res) => {
   if (!validPathComponent(req.params.owner)) {
     return res.status(400).json({ error: 'Invalid input' });
   }
+  const ownerDir = path.join(__dirname, 'uploads', req.params.owner);
+  if (!ownerExists(req.params.owner)) {
+    return res.status(404).json({ error: 'owner_not_found' });
+  }
   const myDir = getUserDir(req);
   const state = loadSharedState(myDir);
   const key = req.params.owner + '/' + req.params.id;
@@ -403,8 +415,6 @@ app.post('/shared-groups/:owner/:id/show', ensureAuthenticated, (req, res) => {
   if (req.body.show) state.showInMy.push(key);
   saveSharedState(myDir, state);
   const email = req.user.emails[0].value;
-  const ownerDir = path.join(__dirname, 'uploads', req.params.owner);
-  ensureDirs(ownerDir);
   const usage = loadUsage(ownerDir);
   if (!usage[req.params.id]) usage[req.params.id] = [];
   usage[req.params.id] = usage[req.params.id].filter(e => e !== email);
@@ -419,7 +429,9 @@ app.get('/shared-cards/:owner/:group', ensureAuthenticated, (req, res) => {
   }
   const email = req.user.emails[0].value;
   const ownerDir = path.join(__dirname, 'uploads', req.params.owner);
-  if (!fs.existsSync(ownerDir)) return res.json([]);
+  if (!ownerExists(req.params.owner)) {
+    return res.status(404).json({ error: 'owner_not_found' });
+  }
   const groups = loadGroups(ownerDir);
   const g = groups.find(x => x.id === req.params.group);
   if (!g || !(g.emails || []).includes(email)) return res.json([]);

--- a/backend/localization/en.json
+++ b/backend/localization/en.json
@@ -45,6 +45,7 @@
     "limitGroups": "Group limit reached",
     "limitEmails": "Email limit exceeded",
     "uploadFailed": "Upload failed",
-    "fileTooLarge": "File too large"
+    "fileTooLarge": "File too large",
+    "ownerNotFound": "Owner not found"
   }
 }

--- a/backend/localization/ru.json
+++ b/backend/localization/ru.json
@@ -45,6 +45,7 @@
     "limitGroups": "Превышен лимит групп",
     "limitEmails": "Слишком много адресов",
     "uploadFailed": "Ошибка загрузки",
-    "fileTooLarge": "Слишком большой файл"
+    "fileTooLarge": "Слишком большой файл",
+    "ownerNotFound": "Владелец не найден"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -92,7 +92,14 @@ function App() {
 
   const loadSharedCards = (owner, id) => {
     fetch(`${API_URL}/shared-cards/${owner}/${id}`, { credentials:'include' })
-      .then(res => res.json())
+      .then(async res => {
+        if(!res.ok){
+          const data = await res.json().catch(()=>({}));
+          if(data.error==='owner_not_found') showError(t('errors.ownerNotFound'));
+          return [];
+        }
+        return res.json();
+      })
       .then(setCards);
   };
 
@@ -467,7 +474,15 @@ function App() {
                 <Box sx={{ display:'flex', alignItems:'center' }}>
                   <Typography sx={{ mr:2 }}>{sg.name} ({sg.count})</Typography>
                   <FormControlLabel control={<Checkbox checked={sg.showInMy} onChange={e=>{
-                    fetch(`${API_URL}/shared-groups/${sg.owner}/${sg.id}/show`, {method:'POST', credentials:'include', headers:{'Content-Type':'application/json'}, body:JSON.stringify({show:e.target.checked})}).then(loadSharedGroups);
+                    fetch(`${API_URL}/shared-groups/${sg.owner}/${sg.id}/show`, {method:'POST', credentials:'include', headers:{'Content-Type':'application/json'}, body:JSON.stringify({show:e.target.checked})})
+                      .then(async res=>{
+                        if(!res.ok){
+                          const data = await res.json().catch(()=>({}));
+                          if(data.error==='owner_not_found') showError(t('errors.ownerNotFound'));
+                          return;
+                        }
+                        loadSharedGroups();
+                      });
                   }} />} label={t('pages.main.showInMyGroups')} />
                   <Button size="small" color="error" onClick={()=>{
                     setConfirmDeleteShared({owner: sg.owner, id: sg.id});
@@ -619,7 +634,16 @@ function App() {
           <Box sx={{ textAlign:'right' }}>
             <Button onClick={()=>setConfirmDeleteShared(null)} sx={{ mr:1 }}>{t('pages.main.cancelButton')}</Button>
             <Button variant="contained" color="error" onClick={()=>{
-              fetch(`${API_URL}/shared-groups/${confirmDeleteShared?.owner}/${confirmDeleteShared?.id}/delete`, {method:'POST', credentials:'include'}).then(()=>{ loadSharedGroups(); setConfirmDeleteShared(null); });
+              fetch(`${API_URL}/shared-groups/${confirmDeleteShared?.owner}/${confirmDeleteShared?.id}/delete`, {method:'POST', credentials:'include'})
+                .then(async res=>{
+                  if(!res.ok){
+                    const data = await res.json().catch(()=>({}));
+                    if(data.error==='owner_not_found') showError(t('errors.ownerNotFound'));
+                    return;
+                  }
+                  loadSharedGroups();
+                  setConfirmDeleteShared(null);
+                });
             }}>{t('pages.main.deleteButton')}</Button>
           </Box>
         </DialogContent>


### PR DESCRIPTION
## Summary
- add `ownerExists` utility to confirm user directories
- check requested owners in shared routes and abort if nonexistent
- avoid creating new directories for unknown owners
- localize new "owner not found" errors and handle them in the frontend

## Testing
- `npm test` *(fails: package.json missing)*
- `npm run lint` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6870b8bbcf6883289c68221e06a04489