### PR TITLE
Use salted hashes for image URLs

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -4,3 +4,4 @@ GOOGLE_CLIENT_SECRET=your_client_secret
 FRONTEND_URL=http://localhost:3000
 SESSION_SECRET=your_session_secret
 MAX_FILE_SIZE=5242880
+SALT=some_random_salt

--- a/backend/data-connector/fs.js
+++ b/backend/data-connector/fs.js
@@ -7,8 +7,8 @@ function getUploadsDir() {
   return BASE_DIR;
 }
 
-function getUserDir(email) {
-  return path.join(BASE_DIR, email);
+function getUserDir(id) {
+  return path.join(BASE_DIR, id);
 }
 
 function ensureDirs(dir) {

--- a/readme.md
+++ b/readme.md
@@ -3,12 +3,12 @@
 This repository contains a simple client-server application for storing discount cards.
 
 ## Backend
-Located in the `backend` directory. It is an Express server using Google OAuth for authentication. Uploaded images are stored per-user based on their email address.
+Located in the `backend` directory. It is an Express server using Google OAuth for authentication. Uploaded images are stored per-user using a salted hash of the user's email so the actual address never appears in URLs.
 
 ### Setup
 ```bash
 cd backend
-cp .env.sample .env        # update with Google credentials
+cp .env.sample .env        # update with Google credentials and set a unique SALT
 npm install
 npm start
 ```


### PR DESCRIPTION
## Summary
- hash user email on login and use the hash as the owner id
- store uploaded files and previews under the hashed id
- generate hashed file names and keep original name/size in metadata
- update env sample and README about new `SALT` variable

## Testing
- `node -c backend/index.js`
- `node -c backend/data-service.js`
- `node -c backend/data-connector/fs.js`

------
https://chatgpt.com/codex/tasks/task_e_6874bce410d08328a522a66a047d71da