### PR TITLE
chore: dockerize backend

### DIFF
--- a/.github/workflows/backend-image.yml
+++ b/.github/workflows/backend-image.yml
@@ -1,0 +1,30 @@
+name: Build and Push Backend Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/backend:latest
+            ghcr.io/${{ github.repository_owner }}/backend:${{ github.sha }}
+          secrets: |
+            npmrc=${{ secrets.NPMRC }}

--- a/.github/workflows/frontend-image.yml
+++ b/.github/workflows/frontend-image.yml
@@ -1,0 +1,32 @@
+name: Build and Push Frontend Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          build-args: |
+            VITE_API_URL=${{ secrets.VITE_API_URL }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/frontend:latest
+            ghcr.io/${{ github.repository_owner }}/frontend:${{ github.sha }}
+          secrets: |
+            npmrc=${{ secrets.NPMRC }}

--- a/.github/workflows/telegram-bot-image.yml
+++ b/.github/workflows/telegram-bot-image.yml
@@ -1,0 +1,30 @@
+name: Build and Push Telegram Bot Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./telegram-bot
+          file: ./telegram-bot/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/telegram-bot:latest
+            ghcr.io/${{ github.repository_owner }}/telegram-bot:${{ github.sha }}
+          secrets: |
+            npmrc=${{ secrets.NPMRC }}

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+.env
+uploads

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,4 +1,4 @@
 node_modules
 npm-debug.log
-.env
+*.env
 uploads

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,4 +1,5 @@
 node_modules
 npm-debug.log
 *.env
+.npmrc
 uploads

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,18 @@
+# Use official Node.js 20 LTS image
+FROM node:20
+
+# Set working directory
+WORKDIR /usr/src/app
+
+# Install dependencies based on package.json and package-lock.json
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Copy source files
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 4000
+
+# Start the server
+CMD ["npm", "start"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 # Use official Node.js 20 LTS image
 FROM node:20
 
@@ -6,7 +7,9 @@ WORKDIR /usr/src/app
 
 # Install dependencies based on package.json and package-lock.json
 COPY package*.json ./
-RUN npm ci --omit=dev
+# Optionally mount a private npm token without baking it into layers
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    npm ci --omit=dev
 
 # Copy source files
 COPY . .

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -4,6 +4,6 @@ services:
   backend:
     build: .
     env_file:
-      - .env
+      - ${ENV_FILE:-.env}
     ports:
       - "${PORT:-4000}:4000"

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -3,24 +3,7 @@ version: '3.9'
 services:
   backend:
     build: .
+    env_file:
+      - ${ENV_FILE:-.env}
     ports:
       - "${PORT:-4000}:4000"
-    environment:
-      - PORT
-      - GOOGLE_CLIENT_ID
-      - GOOGLE_CLIENT_SECRET
-      - FRONTEND_URL
-      - SESSION_SECRET
-      - MAX_FILE_SIZE
-      - SALT
-      - DATA_CONNECTOR
-      - FS_BASE_DIR
-      - MYSQL_HOST
-      - MYSQL_PORT
-      - MYSQL_USER
-      - MYSQL_PASSWORD
-      - MYSQL_DATABASE
-      - ADMIN_EMAILS
-      - REQUIRE_TELEGRAM
-      - TELEGRAM_SECRET
-      - TELEGRAM_GROUP

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3.9'
 
 services:
   backend:
-    build: ./backend
+    build: .
     env_file:
-      - ./backend/.env
+      - .env
     ports:
       - "${PORT:-4000}:4000"

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -3,7 +3,24 @@ version: '3.9'
 services:
   backend:
     build: .
-    env_file:
-      - ${ENV_FILE:-.env}
     ports:
       - "${PORT:-4000}:4000"
+    environment:
+      - PORT
+      - GOOGLE_CLIENT_ID
+      - GOOGLE_CLIENT_SECRET
+      - FRONTEND_URL
+      - SESSION_SECRET
+      - MAX_FILE_SIZE
+      - SALT
+      - DATA_CONNECTOR
+      - FS_BASE_DIR
+      - MYSQL_HOST
+      - MYSQL_PORT
+      - MYSQL_USER
+      - MYSQL_PASSWORD
+      - MYSQL_DATABASE
+      - ADMIN_EMAILS
+      - REQUIRE_TELEGRAM
+      - TELEGRAM_SECRET
+      - TELEGRAM_GROUP

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,4 +1,7 @@
-require('dotenv').config();
+const fs = require('fs');
+if (fs.existsSync('.env')) {
+  require('dotenv').config();
+}
 
 const express = require('express');
 const session = require('express-session');
@@ -7,7 +10,6 @@ const GoogleStrategy = require('passport-google-oauth20').Strategy;
 const cors = require('cors');
 const multer = require('multer');
 const path = require('path');
-const fs = require('fs');
 const crypto = require('crypto');
 const morgan = require('morgan');
 const rateLimit = require('express-rate-limit');
@@ -27,8 +29,6 @@ function getUserEmail(req) {
   return req.user.emails[0].value;
 }
 
-
-require('dotenv').config();
 
 if (!process.env.SESSION_SECRET) {
   console.error('SESSION_SECRET is required');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.9'
+
+services:
+  backend:
+    build: ./backend
+    env_file:
+      - ./backend/.env
+    ports:
+      - "${PORT:-4000}:4000"

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+dist
+*.env
+.npmrc

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,10 +9,11 @@ COPY package*.json ./
 RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
     npm ci --omit=dev
 
-# Copy source and build with env file mounted as secret
+# Copy source and build
 COPY . .
-RUN --mount=type=secret,id=env,target=.env \
-    npm run build
+ARG VITE_API_URL
+ENV VITE_API_URL=$VITE_API_URL
+RUN npm run build
 
 # Runtime stage: serve static files with nginx
 FROM nginx:alpine

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.4
+
+# Build stage: compile the React app
+FROM node:20 AS build
+WORKDIR /usr/src/app
+
+# Install dependencies
+COPY package*.json ./
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    npm ci --omit=dev
+
+# Copy source and build with env file mounted as secret
+COPY . .
+RUN --mount=type=secret,id=env,target=.env \
+    npm run build
+
+# Runtime stage: serve static files with nginx
+FROM nginx:alpine
+COPY --from=build /usr/src/app/dist /usr/share/nginx/html
+EXPOSE 80

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.9'
+
+services:
+  frontend:
+    build:
+      context: .
+      secrets:
+        - env
+    env_file:
+      - ${ENV_FILE:-.env}
+    ports:
+      - "${PORT:-3000}:80"
+
+secrets:
+  env:
+    file: ${ENV_FILE:-.env}

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -4,13 +4,7 @@ services:
   frontend:
     build:
       context: .
-      secrets:
-        - env
-    env_file:
-      - ${ENV_FILE:-.env}
+      args:
+        VITE_API_URL: ${VITE_API_URL}
     ports:
       - "${PORT:-3000}:80"
-
-secrets:
-  env:
-    file: ${ENV_FILE:-.env}

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -6,5 +6,7 @@ services:
       context: .
       args:
         VITE_API_URL: ${VITE_API_URL}
+    env_file:
+      - ${ENV_FILE:-.env}
     ports:
       - "${PORT:-3000}:80"

--- a/readme.md
+++ b/readme.md
@@ -27,16 +27,27 @@ npm run dev
 
 Create a `.env` based on `.env.sample` to configure the API URL.
 
-### Docker (Backend)
+### Docker
 
+#### Backend
 To run the backend in a container, copy the sample environment file and start the stack:
 
 ```bash
-cp backend/.env.sample backend/.env  # update with your credentials
+cd backend
+cp .env.sample .env  # update with your credentials
 docker compose up --build
 ```
 
 The API will be available at `http://localhost:4000` by default. Environment variables are loaded from `backend/.env`.
+
+#### Telegram Bot
+To run the Telegram bot in a container:
+
+```bash
+cd telegram-bot
+cp .env.sample .env  # configure BOT_TOKEN, BACKEND_URL, TELEGRAM_SECRET and TELEGRAM_GROUP_ID
+docker compose up --build
+```
 
 ## Usage
 1. Start the backend and frontend.

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,17 @@ npm run dev
 
 Create a `.env` based on `.env.sample` to configure the API URL.
 
+### Docker (Backend)
+
+To run the backend in a container, copy the sample environment file and start the stack:
+
+```bash
+cp backend/.env.sample backend/.env  # update with your credentials
+docker compose up --build
+```
+
+The API will be available at `http://localhost:4000` by default. Environment variables are loaded from `backend/.env`.
+
 ## Usage
 1. Start the backend and frontend.
 2. Open the frontend URL in your browser.

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,16 @@ Store secrets outside the images using env files, Docker secrets, or a secrets m
 
 In GitHub Actions, define all required variables as repository Secrets and expose them as environment variables. Do not commit or copy any `.env` files in CI; secrets should come only from the Actions secrets store so nothing sensitive gets baked into image layers.
 
+### GitHub Actions
+
+Manual workflows in `.github/workflows` build and publish container images to GitHub Container Registry. Trigger them from the **Actions** tab:
+
+- **Build and Push Backend Image** — builds the `backend` service and pushes `ghcr.io/<owner>/backend`.
+- **Build and Push Frontend Image** — builds the `frontend` service (injecting `VITE_API_URL` from repository secrets) and pushes `ghcr.io/<owner>/frontend`.
+- **Build and Push Telegram Bot Image** — builds the `telegram-bot` service and pushes `ghcr.io/<owner>/telegram-bot`.
+
+Each workflow logs in to GHCR using `GITHUB_TOKEN`. Optional private npm credentials can be supplied via the `NPMRC` secret; it is mounted as a build-time secret so tokens never enter image layers.
+
 ## Usage
 1. Start the backend and frontend.
 2. Open the frontend URL in your browser.

--- a/readme.md
+++ b/readme.md
@@ -35,10 +35,11 @@ To run the backend in a container, copy the sample environment file and start th
 ```bash
 cd backend
 cp .env.sample .env  # update with your credentials
+# defaults to .env; override with ENV_FILE=.prod.env or similar
 docker compose up --build
 ```
 
-The API will be available at `http://localhost:4000` by default. Environment variables are loaded from `backend/.env`.
+The API will be available at `http://localhost:4000` by default. Environment variables are loaded from `backend/.env` unless overridden with `ENV_FILE`, e.g. `ENV_FILE=.prod.env docker compose up --build`.
 
 #### Telegram Bot
 To run the Telegram bot in a container:
@@ -46,6 +47,7 @@ To run the Telegram bot in a container:
 ```bash
 cd telegram-bot
 cp .env.sample .env  # configure BOT_TOKEN, BACKEND_URL, TELEGRAM_SECRET and TELEGRAM_GROUP_ID
+# defaults to .env; override with ENV_FILE=.prod.env or similar
 docker compose up --build
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -8,12 +8,11 @@ Located in the `backend` directory. It is an Express server using Google OAuth f
 ### Setup
 ```bash
 cd backend
-cp .env.sample .env        # update with Google credentials and set a unique SALT
+# optionally copy .env.sample to .env for local development
 npm install
 npm start
 ```
-`ADMIN_EMAILS` in `.env` should contain a comma-separated list of emails allowed to access admin APIs.
-`TELEGRAM_GROUP` should contain the Telegram bot username used to issue group invites.
+`ADMIN_EMAILS` and `TELEGRAM_GROUP` should be provided via environment variables.
 
 ## Frontend
 Located in the `frontend` directory. Built with React and Material UI using Vite.
@@ -25,21 +24,19 @@ npm install
 npm run dev
 ```
 
-Create a `.env` based on `.env.sample` to configure the API URL.
+Set `VITE_API_URL` in your environment or create a local `.env` based on `.env.sample`.
 
 ### Docker
 
 #### Backend
-To run the backend in a container, copy the sample environment file and start the stack:
+To run the backend in a container, define the required variables in your shell or pass an env file:
 
 ```bash
 cd backend
-cp .env.sample .env  # update with your credentials
-# defaults to .env; override with ENV_FILE=.prod.env or similar
-docker compose up --build
+docker compose --env-file .env up --build
 ```
 
-The API will be available at `http://localhost:4000` by default. Environment variables are loaded from `backend/.env` unless overridden with `ENV_FILE`, e.g. `ENV_FILE=.prod.env docker compose up --build`.
+The API will be available at `http://localhost:4000` by default. Environment variables come from your shell or the file provided with `--env-file`.
 
 Secrets from `.env` are never copied into the image: `*.env` and `.npmrc` are ignored by Docker. If you rely on private npm packages, pass your `.npmrc` at build time so tokens do not persist in layers:
 
@@ -53,32 +50,30 @@ To build and serve the frontend from a container:
 
 ```bash
 cd frontend
-cp .env.sample .env  # configure VITE_API_URL
-# defaults to .env; override with ENV_FILE=.prod.env or similar
-docker compose up --build
+docker compose --env-file .env up --build
 ```
 
-The React app is compiled with the environment file mounted as a BuildKit secret, so the `.env` contents are not baked into image layers. The site will be available at `http://localhost:3000` by default.
+Set `VITE_API_URL` in the environment file or shell before building. The site will be available at `http://localhost:3000` by default.
 
 #### Telegram Bot
 To run the Telegram bot in a container:
 
 ```bash
 cd telegram-bot
-cp .env.sample .env  # configure BOT_TOKEN, BACKEND_URL, TELEGRAM_SECRET and TELEGRAM_GROUP_ID
-# defaults to .env; override with ENV_FILE=.prod.env or similar
-docker compose up --build
+docker compose --env-file .env up --build
 ```
+
+Provide `BOT_TOKEN`, `BACKEND_URL`, `TELEGRAM_SECRET` and `TELEGRAM_GROUP_ID` via environment variables or an env file.
 
 ## Hosting
 
 Each project has its own `docker-compose.yml`. To deploy, copy the project folder to your server, create an environment file such as `.prod.env`, and run:
 
 ```bash
-ENV_FILE=.prod.env docker compose up -d --build
+docker compose --env-file .prod.env up -d --build
 ```
 
-Repeat for `backend`, `frontend`, and `telegram-bot`. Keep your `.env` files out of version control and restrict their permissions on the host. Build images locally or in CI and push them to a registry if desired:
+Repeat for `backend`, `frontend`, and `telegram-bot`. Keep your environment files out of version control and restrict their permissions on the host. Build images locally or in CI and push them to a registry if desired:
 
 ```bash
 docker compose build
@@ -87,6 +82,8 @@ docker push your-registry/anycard-frontend:latest
 ```
 
 Store secrets outside the images using env files, Docker secrets, or a secrets manager, and regularly scan built images to ensure nothing sensitive slipped into the layers.
+
+In GitHub Actions, define all required variables as repository Secrets and expose them as environment variables. No `.env` file is needed in CI.
 
 ## Usage
 1. Start the backend and frontend.
@@ -101,7 +98,7 @@ in the group and stores an email to Telegram ID mapping via the backend API.
 ### Setup
 ```bash
 cd telegram-bot
-cp .env.sample .env  # configure BOT_TOKEN, BACKEND_URL, TELEGRAM_SECRET and TELEGRAM_GROUP_ID
+# configure BOT_TOKEN, BACKEND_URL, TELEGRAM_SECRET and TELEGRAM_GROUP_ID in your environment
 npm install
 npm start
 ```

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,16 @@ docker compose up --build
 
 The API will be available at `http://localhost:4000` by default. Environment variables are loaded from `backend/.env` unless overridden with `ENV_FILE`, e.g. `ENV_FILE=.prod.env docker compose up --build`.
 
+Secrets from `.env` are never copied into the image: `*.env` and `.npmrc` are ignored by Docker. If you rely on private npm packages, pass your `.npmrc` at build time so tokens do not persist in layers:
+
+```bash
+docker compose build --secret npmrc=.npmrc
+```
+
+Runtime secrets like API keys or database credentials should be stored outside the image (e.g. in environment files or a secret manager).
+
+The same approach applies to the Telegram bot image.
+
 #### Telegram Bot
 To run the Telegram bot in a container:
 

--- a/readme.md
+++ b/readme.md
@@ -48,8 +48,17 @@ docker compose build --secret npmrc=.npmrc
 ```
 
 Runtime secrets like API keys or database credentials should be stored outside the image (e.g. in environment files or a secret manager).
+#### Frontend
+To build and serve the frontend from a container:
 
-The same approach applies to the Telegram bot image.
+```bash
+cd frontend
+cp .env.sample .env  # configure VITE_API_URL
+# defaults to .env; override with ENV_FILE=.prod.env or similar
+docker compose up --build
+```
+
+The React app is compiled with the environment file mounted as a BuildKit secret, so the `.env` contents are not baked into image layers. The site will be available at `http://localhost:3000` by default.
 
 #### Telegram Bot
 To run the Telegram bot in a container:
@@ -60,6 +69,24 @@ cp .env.sample .env  # configure BOT_TOKEN, BACKEND_URL, TELEGRAM_SECRET and TEL
 # defaults to .env; override with ENV_FILE=.prod.env or similar
 docker compose up --build
 ```
+
+## Hosting
+
+Each project has its own `docker-compose.yml`. To deploy, copy the project folder to your server, create an environment file such as `.prod.env`, and run:
+
+```bash
+ENV_FILE=.prod.env docker compose up -d --build
+```
+
+Repeat for `backend`, `frontend`, and `telegram-bot`. Keep your `.env` files out of version control and restrict their permissions on the host. Build images locally or in CI and push them to a registry if desired:
+
+```bash
+docker compose build
+docker tag frontend_frontend:latest your-registry/anycard-frontend:latest
+docker push your-registry/anycard-frontend:latest
+```
+
+Store secrets outside the images using env files, Docker secrets, or a secrets manager, and regularly scan built images to ensure nothing sensitive slipped into the layers.
 
 ## Usage
 1. Start the backend and frontend.

--- a/readme.md
+++ b/readme.md
@@ -29,14 +29,14 @@ Set `VITE_API_URL` in your environment or create a local `.env` based on `.env.s
 ### Docker
 
 #### Backend
-To run the backend in a container, define the required variables in your shell or pass an env file:
+To build and run the backend, point `ENV_FILE` at the desired env file:
 
 ```bash
 cd backend
-docker compose --env-file .env up --build
+ENV_FILE=.env docker compose --env-file $ENV_FILE up --build
 ```
 
-The API will be available at `http://localhost:4000` by default. Environment variables come from your shell or the file provided with `--env-file`.
+Swap `.env` for `.local.env`, `.staging.env`, or `.prod.env` as needed. The chosen file supplies variables at build time and run time but is ignored by Docker so its contents never enter the image. The API will be available at `http://localhost:4000` by default.
 
 Secrets from `.env` are never copied into the image: `*.env` and `.npmrc` are ignored by Docker. If you rely on private npm packages, pass your `.npmrc` at build time so tokens do not persist in layers:
 
@@ -46,31 +46,32 @@ docker compose build --secret npmrc=.npmrc
 
 Runtime secrets like API keys or database credentials should be stored outside the image (e.g. in environment files or a secret manager).
 #### Frontend
-To build and serve the frontend from a container:
+To build and serve the frontend:
 
 ```bash
 cd frontend
-docker compose --env-file .env up --build
+ENV_FILE=.env docker compose --env-file $ENV_FILE up --build
 ```
 
-Set `VITE_API_URL` in the environment file or shell before building. The site will be available at `http://localhost:3000` by default.
+Replace `.env` with whichever configuration you need. `VITE_API_URL` and other values come from that file during the build, and the resulting static site contains no secrets. The site will be available at `http://localhost:3000` by default.
 
 #### Telegram Bot
 To run the Telegram bot in a container:
 
 ```bash
 cd telegram-bot
-docker compose --env-file .env up --build
+ENV_FILE=.env docker compose --env-file $ENV_FILE up --build
 ```
 
-Provide `BOT_TOKEN`, `BACKEND_URL`, `TELEGRAM_SECRET` and `TELEGRAM_GROUP_ID` via environment variables or an env file.
+Provide `BOT_TOKEN`, `BACKEND_URL`, `TELEGRAM_SECRET` and `TELEGRAM_GROUP_ID` in the selected env file.
 
 ## Hosting
 
 Each project has its own `docker-compose.yml`. To deploy, copy the project folder to your server, create an environment file such as `.prod.env`, and run:
 
 ```bash
-docker compose --env-file .prod.env up -d --build
+cd <project>
+ENV_FILE=.prod.env docker compose --env-file $ENV_FILE up -d --build
 ```
 
 Repeat for `backend`, `frontend`, and `telegram-bot`. Keep your environment files out of version control and restrict their permissions on the host. Build images locally or in CI and push them to a registry if desired:
@@ -83,7 +84,7 @@ docker push your-registry/anycard-frontend:latest
 
 Store secrets outside the images using env files, Docker secrets, or a secrets manager, and regularly scan built images to ensure nothing sensitive slipped into the layers.
 
-In GitHub Actions, define all required variables as repository Secrets and expose them as environment variables. No `.env` file is needed in CI.
+In GitHub Actions, define all required variables as repository Secrets and expose them as environment variables. Do not commit or copy any `.env` files in CI; secrets should come only from the Actions secrets store so nothing sensitive gets baked into image layers.
 
 ## Usage
 1. Start the backend and frontend.

--- a/telegram-bot/.dockerignore
+++ b/telegram-bot/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.env

--- a/telegram-bot/.dockerignore
+++ b/telegram-bot/.dockerignore
@@ -1,3 +1,3 @@
 node_modules
 npm-debug.log
-.env
+*.env

--- a/telegram-bot/.dockerignore
+++ b/telegram-bot/.dockerignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 *.env
+.npmrc

--- a/telegram-bot/Dockerfile
+++ b/telegram-bot/Dockerfile
@@ -1,0 +1,15 @@
+# Use official Node.js 20 LTS image
+FROM node:20
+
+# Set working directory
+WORKDIR /usr/src/app
+
+# Install dependencies based on package.json and package-lock.json
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Copy source files
+COPY . .
+
+# Start the bot
+CMD ["npm", "start"]

--- a/telegram-bot/Dockerfile
+++ b/telegram-bot/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 # Use official Node.js 20 LTS image
 FROM node:20
 
@@ -6,7 +7,9 @@ WORKDIR /usr/src/app
 
 # Install dependencies based on package.json and package-lock.json
 COPY package*.json ./
-RUN npm ci --omit=dev
+# Optionally mount a private npm token without baking it into layers
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    npm ci --omit=dev
 
 # Copy source files
 COPY . .

--- a/telegram-bot/docker-compose.yml
+++ b/telegram-bot/docker-compose.yml
@@ -4,4 +4,4 @@ services:
   telegram-bot:
     build: .
     env_file:
-      - .env
+      - ${ENV_FILE:-.env}

--- a/telegram-bot/docker-compose.yml
+++ b/telegram-bot/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.9'
+
+services:
+  telegram-bot:
+    build: .
+    env_file:
+      - .env

--- a/telegram-bot/docker-compose.yml
+++ b/telegram-bot/docker-compose.yml
@@ -3,8 +3,5 @@ version: '3.9'
 services:
   telegram-bot:
     build: .
-    environment:
-      - BOT_TOKEN
-      - BACKEND_URL
-      - TELEGRAM_SECRET
-      - TELEGRAM_GROUP_ID
+    env_file:
+      - ${ENV_FILE:-.env}

--- a/telegram-bot/docker-compose.yml
+++ b/telegram-bot/docker-compose.yml
@@ -3,5 +3,8 @@ version: '3.9'
 services:
   telegram-bot:
     build: .
-    env_file:
-      - ${ENV_FILE:-.env}
+    environment:
+      - BOT_TOKEN
+      - BACKEND_URL
+      - TELEGRAM_SECRET
+      - TELEGRAM_GROUP_ID

--- a/telegram-bot/index.js
+++ b/telegram-bot/index.js
@@ -1,5 +1,8 @@
+const fs = require('fs');
 const path = require('path');
-require('dotenv').config({ path: path.join(__dirname, '.env') });
+if (fs.existsSync(path.join(__dirname, '.env'))) {
+  require('dotenv').config({ path: path.join(__dirname, '.env') });
+}
 const TelegramBot = require('node-telegram-bot-api');
 const axios = require('axios');
 


### PR DESCRIPTION
## Summary
- add Dockerfile for backend using Node 20 LTS
- add docker-compose to load environment variables from backend/.env
- document containerized backend setup in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899d4886ea88328a90e415c8782ab65